### PR TITLE
Implement latest MCP spec in ChatLima

### DIFF
--- a/MCP_UPGRADE_GUIDE.md
+++ b/MCP_UPGRADE_GUIDE.md
@@ -1,0 +1,318 @@
+# MCP 1.13.0 Upgrade Guide for ChatLima
+
+This guide outlines the steps needed to upgrade ChatLima from MCP SDK 1.12.0 to 1.13.0 to leverage the latest Model Context Protocol features and improvements.
+
+## Overview
+
+MCP 1.13.0 introduces several important changes including:
+- **MCP-Protocol-Version header requirement** for HTTP transport (BREAKING CHANGE)
+- **Resource template reference naming changes** (BREAKING CHANGE)
+- **Enhanced metadata support** with `_meta` fields
+- **Tool, resource, and prompt titles** for better UI display
+- **Resource links** in tool outputs
+- **Context-aware completions**
+- **Elicitation capability** for interactive workflows
+- **Resource Indicators** (RFC 8707) for security
+
+## Step 1: Update Package Dependencies
+
+First, update the MCP SDK to the latest version:
+
+```bash
+pnpm update @modelcontextprotocol/sdk@^1.13.0
+```
+
+Update your `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.13.0"
+  }
+}
+```
+
+## Step 2: Update StreamableHTTP Transport (BREAKING CHANGE)
+
+The most critical change is the **MCP-Protocol-Version header requirement** for HTTP transport.
+
+### Current Implementation Issue
+
+Your current code in `app/api/chat/route.ts` (lines 378-383) creates `StreamableHTTPClientTransport` without the required protocol version header:
+
+```typescript
+// CURRENT CODE - NEEDS UPDATE
+finalTransportForClient = new StreamableHTTPClientTransport(transportUrl, {
+  requestInit: {
+    headers: Object.keys(headers).length > 0 ? headers : undefined
+  }
+});
+```
+
+### Updated Implementation
+
+```typescript
+// UPDATED CODE - With MCP-Protocol-Version header
+finalTransportForClient = new StreamableHTTPClientTransport(transportUrl, {
+  requestInit: {
+    headers: {
+      'MCP-Protocol-Version': '2025-06-18', // Required for MCP 1.13.0
+      ...headers // Spread existing headers
+    }
+  }
+});
+```
+
+## Step 3: Handle Resource Template Reference Changes
+
+If your code uses `ResourceReference`, update it to `ResourceTemplateReference`:
+
+```typescript
+// OLD (1.12.0)
+import { ResourceReference } from '@modelcontextprotocol/sdk';
+
+// NEW (1.13.0)  
+import { ResourceTemplateReference } from '@modelcontextprotocol/sdk';
+```
+
+## Step 4: Add Enhanced Metadata Support
+
+### Tool Metadata with Titles
+
+Update your MCP server configurations to include `title` fields for better UI display:
+
+```typescript
+// In lib/context/mcp-context.tsx - Update MCPServer interface
+export interface MCPServer {
+  id: string;
+  name: string;
+  title?: string; // NEW: Add title for display
+  url: string;
+  type: 'sse' | 'stdio' | 'streamable-http';
+  command?: string;
+  args?: string[];
+  env?: KeyValuePair[];
+  headers?: KeyValuePair[];
+  description?: string;
+  _meta?: Record<string, any>; // NEW: Add _meta support
+}
+```
+
+### Update MCP Server Manager Component
+
+In `components/mcp-server-manager.tsx`, add support for displaying titles:
+
+```typescript
+// Add title field to your server creation/editing forms
+<div className="space-y-2">
+  <Label htmlFor="name">Name (ID)</Label>
+  <Input
+    id="name"
+    placeholder="e.g., filesystem-server"
+    value={formData.name}
+    onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+  />
+</div>
+
+<div className="space-y-2">
+  <Label htmlFor="title">Title (Display Name)</Label>
+  <Input
+    id="title"
+    placeholder="e.g., File System Access"
+    value={formData.title || ''}
+    onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+  />
+</div>
+```
+
+## Step 5: Implement Resource Links Support
+
+Update your tool calling logic to handle resource links in tool outputs:
+
+```typescript
+// In app/api/chat/route.ts - Update tool result processing
+interface ResourceLink {
+  type: 'resource_link';
+  uri: string;
+  name?: string;
+  mimeType?: string;
+  description?: string;
+}
+
+interface ToolCallResult {
+  content: Array<{
+    type: 'text' | 'resource_link';
+    text?: string;
+    uri?: string;
+    name?: string;
+    mimeType?: string;
+    description?: string;
+  }>;
+  isError?: boolean;
+}
+```
+
+## Step 6: Add Context-Aware Completions Support
+
+If you plan to use completions, update to support the new `context` field:
+
+```typescript
+// NEW: Context-aware completion support
+interface CompletionRequest {
+  ref: {
+    type: 'ref/prompt' | 'ref/resource';
+    name?: string;
+    uri?: string;
+  };
+  argument: {
+    name: string;
+    value: string;
+  };
+  context?: {
+    arguments?: Record<string, any>;
+  }; // NEW: Context support
+}
+```
+
+## Step 7: Implement Elicitation Capability (Optional)
+
+For interactive workflows, you can implement elicitation support:
+
+```typescript
+// NEW: Elicitation capability
+interface ElicitationRequest {
+  message: string;
+  requestedSchema: {
+    type: string;
+    properties: Record<string, any>;
+    required?: string[];
+  };
+}
+
+// In your MCP client setup, add elicitation capability
+const clientCapabilities = {
+  elicitation: {}, // NEW: Declare elicitation support
+  // ... other capabilities
+};
+```
+
+## Step 8: Update Error Handling
+
+Update error handling to use the new "reject" terminology instead of "decline":
+
+```typescript
+// OLD
+if (result.action === 'decline') {
+  // handle decline
+}
+
+// NEW  
+if (result.action === 'reject') {
+  // handle rejection
+}
+```
+
+## Step 9: Enhanced Security with Resource Indicators
+
+For production deployments, implement Resource Indicators (RFC 8707) support:
+
+```typescript
+// In StreamableHTTP transport configuration
+finalTransportForClient = new StreamableHTTPClientTransport(transportUrl, {
+  requestInit: {
+    headers: {
+      'MCP-Protocol-Version': '2025-06-18',
+      'Resource': transportUrl.origin, // RFC 8707 Resource Indicator
+      ...headers
+    }
+  }
+});
+```
+
+## Step 10: Update Development Dependencies
+
+Update any development tools that might be affected:
+
+```bash
+# Update all MCP-related dependencies if any
+pnpm update
+```
+
+## Step 11: Testing the Upgrade
+
+1. **Test Existing MCP Servers**: Ensure all your current MCP server connections still work
+2. **Test StreamableHTTP**: Verify that HTTP-based MCP servers can connect properly
+3. **Test Error Handling**: Ensure error cases are handled gracefully
+4. **Test UI**: Verify that server titles display correctly in the MCP Server Manager
+
+## Step 12: Optional Enhancements
+
+Consider implementing these new features:
+
+### A. Enhanced Tool Output with Resource Links
+
+```typescript
+// Example of returning resource links from tools
+const toolResult = {
+  content: [
+    { type: "text", text: "Found the following files:" },
+    {
+      type: "resource_link",
+      uri: "file:///project/README.md", 
+      name: "README.md",
+      mimeType: "text/markdown",
+      description: "Project documentation"
+    }
+  ]
+};
+```
+
+### B. Interactive Workflows with Elicitation
+
+```typescript
+// Example elicitation for user confirmation
+const userInput = await mcpClient.elicitInput({
+  message: "Do you want to proceed with deleting these files?",
+  requestedSchema: {
+    type: "object",
+    properties: {
+      confirm: {
+        type: "boolean",
+        title: "Confirm deletion"
+      }
+    },
+    required: ["confirm"]
+  }
+});
+```
+
+## Breaking Changes Summary
+
+1. **MCP-Protocol-Version header**: Required for HTTP transport
+2. **ResourceReference → ResourceTemplateReference**: Update imports
+3. **decline → reject**: Update error handling terminology
+
+## Migration Checklist
+
+- [ ] Update MCP SDK to 1.13.0
+- [ ] Add MCP-Protocol-Version header to StreamableHttp transport
+- [ ] Update ResourceReference imports if used
+- [ ] Add title and _meta fields to MCP server interface
+- [ ] Update server manager UI to support titles
+- [ ] Test all existing MCP server connections
+- [ ] Update error handling from "decline" to "reject"
+- [ ] Consider implementing elicitation for interactive workflows
+- [ ] Consider implementing resource links for better tool outputs
+
+## Resources
+
+- [MCP 1.13.0 Release Notes](https://github.com/modelcontextprotocol/typescript-sdk/releases/tag/1.13.0)
+- [MCP Specification 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/changelog)
+- [MCP TypeScript SDK Documentation](https://github.com/modelcontextprotocol/typescript-sdk)
+
+## Support
+
+If you encounter issues during the upgrade:
+1. Check the [MCP GitHub Discussions](https://github.com/modelcontextprotocol/typescript-sdk/discussions)
+2. Review the [MCP specification](https://modelcontextprotocol.io/)
+3. Test with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) for debugging

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -381,7 +381,10 @@ export async function POST(req: Request) {
         finalTransportForClient = new StreamableHTTPClientTransport(transportUrl, {
           // sessionId: nanoid(), // Optionally, provide a session ID if your server uses it
           requestInit: {
-            headers: Object.keys(headers).length > 0 ? headers : undefined
+            headers: {
+              'MCP-Protocol-Version': '2025-06-18', // Required for MCP 1.13.0+
+              ...headers // Spread existing headers after protocol version
+            }
           }
         });
       } else if (mcpServer.type === 'stdio') {

--- a/components/mcp-server-manager.tsx
+++ b/components/mcp-server-manager.tsx
@@ -38,6 +38,7 @@ import { KeyValuePair, MCPServer } from "@/lib/context/mcp-context";
 // Default template for a new MCP server
 const INITIAL_NEW_SERVER: Omit<MCPServer, 'id'> = {
     name: '',
+    title: '',
     url: '',
     type: 'sse',
     command: 'node',
@@ -307,6 +308,7 @@ export const MCPServerManager = ({
         setEditingServerId(server.id);
         setNewServer({
             name: server.name,
+            title: server.title,
             url: server.url,
             type: server.type,
             command: server.command,
@@ -515,6 +517,25 @@ export const MCPServerManager = ({
                                     placeholder="My MCP Server"
                                     className="relative z-0"
                                 />
+                                <p className="text-xs text-muted-foreground">
+                                    Unique identifier for this server
+                                </p>
+                            </div>
+
+                            <div className="grid gap-1.5">
+                                <Label htmlFor="title">
+                                    Display Title (Optional)
+                                </Label>
+                                <Input
+                                    id="title"
+                                    value={newServer.title || ''}
+                                    onChange={(e) => setNewServer({ ...newServer, title: e.target.value })}
+                                    placeholder="File System Access"
+                                    className="relative z-0"
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    Human-friendly name for UI display
+                                </p>
                             </div>
 
                             <div className="grid gap-1.5">

--- a/lib/context/mcp-context.tsx
+++ b/lib/context/mcp-context.tsx
@@ -13,6 +13,7 @@ export interface KeyValuePair {
 export interface MCPServer {
   id: string;
   name: string;
+  title?: string;
   url: string;
   type: 'sse' | 'stdio' | 'streamable-http';
   command?: string;
@@ -20,6 +21,7 @@ export interface MCPServer {
   env?: KeyValuePair[];
   headers?: KeyValuePair[];
   description?: string;
+  _meta?: Record<string, any>;
 }
 
 // Type for processed MCP server config for API
@@ -30,6 +32,8 @@ export interface MCPServerApi {
   args?: string[];
   env?: KeyValuePair[];
   headers?: KeyValuePair[];
+  title?: string;
+  _meta?: Record<string, any>;
 }
 
 interface MCPContextType {
@@ -70,7 +74,9 @@ export function MCPProvider(props: { children: React.ReactNode }) {
         command: server.command,
         args: server.args,
         env: server.env,
-        headers: server.headers
+        headers: server.headers,
+        title: server.title,
+        _meta: server._meta
       }));
     
     setMcpServersForApi(processedServers);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@ai-sdk/react": "^1.2.9",
     "@ai-sdk/ui-utils": "^1.2.10",
     "@ai-sdk/xai": "^1.2.14",
-    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/sdk": "^1.13.0",
     "@neondatabase/serverless": "^1.0.0",
     "@openrouter/ai-sdk-provider": "^0.4.5",
     "@polar-sh/better-auth": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.2.14
         version: 1.2.14(zod@3.24.2)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.12.0
-        version: 1.12.0
+        specifier: ^1.13.0
+        version: 1.13.0
       '@neondatabase/serverless':
         specifier: ^1.0.0
         version: 1.0.0
@@ -43,13 +43,13 @@ importers:
         version: 0.4.5(zod@3.24.2)
       '@polar-sh/better-auth':
         specifier: ^0.1.1
-        version: 0.1.1(@polar-sh/sdk@0.32.13(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2))(better-auth@1.2.7)
+        version: 0.1.1(@polar-sh/sdk@0.32.13(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2))(better-auth@1.2.7)
       '@polar-sh/nextjs':
         specifier: ^0.4.0
-        version: 0.4.0(@modelcontextprotocol/sdk@1.12.0)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(zod@3.24.2)
+        version: 0.4.0(@modelcontextprotocol/sdk@1.13.0)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(zod@3.24.2)
       '@polar-sh/sdk':
         specifier: ^0.32.13
-        version: 0.32.13(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2)
+        version: 0.32.13(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2)
       '@radix-ui/react-accordion':
         specifier: ^1.2.7
         version: 1.2.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1025,8 +1025,8 @@ packages:
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
-  '@modelcontextprotocol/sdk@1.12.0':
-    resolution: {integrity: sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==}
+  '@modelcontextprotocol/sdk@1.13.0':
+    resolution: {integrity: sha512-P5FZsXU0kY881F6Hbk9GhsYx02/KgWK1DYf7/tyE/1lcFKhDYPQR9iYjhQXJn+Sg6hQleMo3DB7h7+p4wgp2Lw==}
     engines: {node: '>=18'}
 
   '@mrleebo/prisma-ast@0.12.1':
@@ -5534,7 +5534,7 @@ snapshots:
 
   '@levischuck/tiny-cbor@0.2.11': {}
 
-  '@modelcontextprotocol/sdk@1.12.0':
+  '@modelcontextprotocol/sdk@1.13.0':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
@@ -5699,34 +5699,34 @@ snapshots:
     dependencies:
       playwright: 1.52.0
 
-  '@polar-sh/adapter-utils@0.2.0(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2)':
+  '@polar-sh/adapter-utils@0.2.0(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2)':
     dependencies:
-      '@polar-sh/sdk': 0.32.13(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2)
+      '@polar-sh/sdk': 0.32.13(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - zod
 
-  '@polar-sh/better-auth@0.1.1(@polar-sh/sdk@0.32.13(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2))(better-auth@1.2.7)':
+  '@polar-sh/better-auth@0.1.1(@polar-sh/sdk@0.32.13(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2))(better-auth@1.2.7)':
     dependencies:
-      '@polar-sh/sdk': 0.32.13(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2)
+      '@polar-sh/sdk': 0.32.13(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2)
       better-auth: 1.2.7
       zod: 3.24.2
 
-  '@polar-sh/nextjs@0.4.0(@modelcontextprotocol/sdk@1.12.0)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(zod@3.24.2)':
+  '@polar-sh/nextjs@0.4.0(@modelcontextprotocol/sdk@1.13.0)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(zod@3.24.2)':
     dependencies:
-      '@polar-sh/adapter-utils': 0.2.0(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2)
-      '@polar-sh/sdk': 0.32.13(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2)
+      '@polar-sh/adapter-utils': 0.2.0(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2)
+      '@polar-sh/sdk': 0.32.13(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2)
       next: 15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - zod
 
-  '@polar-sh/sdk@0.32.13(@modelcontextprotocol/sdk@1.12.0)(zod@3.24.2)':
+  '@polar-sh/sdk@0.32.13(@modelcontextprotocol/sdk@1.13.0)(zod@3.24.2)':
     dependencies:
       standardwebhooks: 1.0.0
       zod: 3.24.2
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.12.0
+      '@modelcontextprotocol/sdk': 1.13.0
 
   '@prisma/client@5.22.0(prisma@5.22.0)':
     optionalDependencies:


### PR DESCRIPTION
ChatLima was upgraded to use the latest Model Context Protocol (MCP) 1.13.0 specification.

Key changes include:

*   The `@modelcontextprotocol/sdk` dependency in `package.json` and `pnpm-lock.yaml` was updated to `^1.13.0`.
*   A critical breaking change was addressed in `app/api/chat/route.ts` by adding the `MCP-Protocol-Version: 2025-06-18` header to `StreamableHTTPClientTransport` requests, which is now required by MCP 1.13.0.
*   The `MCPServer` and `MCPServerApi` interfaces in `lib/context/mcp-context.tsx` were extended to include `title` and `_meta` fields, enabling enhanced metadata support.
*   The `MCPProvider` in `lib/context/mcp-context.tsx` was updated to process and pass these new `title` and `_meta` fields.
*   The `MCPServerManager` component in `components/mcp-server-manager.tsx` was modified to include a "Display Title" input field, improving the user interface for managing MCP servers.
*   A comprehensive `MCP_UPGRADE_GUIDE.md` was created, detailing the migration steps, breaking changes, and new features of MCP 1.13.0.
*   Dependencies were reinstalled using `pnpm install` to apply the updates.