### PR TITLE
Fix markdown text alignment issue

### DIFF
--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -34,12 +34,12 @@ const components: Partial<Components> = {
     );
   },
   ol: ({ node, children, ...props }) => (
-    <ol className="list-decimal list-outside ml-4 space-y-0.5 my-1.5" {...props}>
+    <ol className="list-decimal list-inside ml-4 space-y-0.5 my-1.5" {...props}>
       {children}
     </ol>
   ),
   ul: ({ node, children, ...props }) => (
-    <ul className="list-disc list-outside ml-4 space-y-0.5 my-1.5" {...props}>
+    <ul className="list-disc list-inside ml-4 space-y-0.5 my-1.5" {...props}>
       {children}
     </ul>
   ),


### PR DESCRIPTION
The issue of list markers (numbers/bullets) being cut off on the left side was addressed.

*   The problem originated in `components/markdown.tsx`, where `ol` and `ul` elements used the `list-outside` class.
*   `list-outside` positions markers outside the content area. Combined with the existing `ml-4` margin and the container's padding, there was insufficient space, causing the markers to be truncated.
*   The fix involved modifying `components/markdown.tsx` to change `list-outside` to `list-inside` for both `ol` and `ul` elements.
*   This change ensures that list markers are rendered within the content area, preventing them from being cut off, while the `ml-4` margin continues to provide the intended indentation.